### PR TITLE
fix: remove errors when no Internet connection is available

### DIFF
--- a/lua/codeium/api.lua
+++ b/lua/codeium/api.lua
@@ -262,8 +262,8 @@ function Server:new()
 			request_id = 0
 
 			if err then
-				if err.status == 408 then
-					-- Timeout error
+                if err.status == 503 or err.status == 408 then
+					-- Service Unavailable or Timeout error
 					return callback(false, nil)
 				end
 


### PR DESCRIPTION
I've noticed that when I lose Internet connection, on every keystroke, I get a `503 Service Unavailable` error (image attached).
In order to remove the 503 messages, we could just check the error code, just like the `408 Request Timeout`.

![codeium-error](https://user-images.githubusercontent.com/61119347/227227764-d3ad0b54-5df7-4f93-867a-9db8db3f6957.png)
