### PR TITLE
Add kind highlight group

### DIFF
--- a/lua/codeium/source.lua
+++ b/lua/codeium/source.lua
@@ -35,6 +35,7 @@ local function codeium_to_cmp(comp, offset, right)
 		insertText = label,
 		cmp = {
 			kind_text = "Codeium",
+			kind_hl_group = "CmpItemKindCodeium",
 		},
 	}
 end


### PR DESCRIPTION
Add a codeium cmp source with a builtin highlight group CmpItemKindCodeium, so users can add their own highlight, for example:

`vim.api.nvim_set_hl(0, "CmpItemKindCodeium", {fg ="#6CC644"})`