### PR TITLE
fix: replace full completion range

### DIFF
--- a/lua/codeium/source.lua
+++ b/lua/codeium/source.lua
@@ -21,6 +21,17 @@ local function codeium_to_cmp(comp, offset, right)
 		label = string.sub(label, 1, -#right - 1)
 	end
 
+	local range = {
+		start = {
+			line = comp.range.startPosition.row + 1,
+			character = offset - 1,
+		},
+		["end"] = {
+			line = comp.range.endPosition.row + 1,
+			character = comp.range.endPosition.col,
+		},
+	}
+
 	return {
 		type = 1,
 		documentation = {
@@ -33,6 +44,11 @@ local function codeium_to_cmp(comp, offset, right)
 		},
 		label = label,
 		insertText = label,
+		textEdit = {
+			newText = label,
+			insert = range,
+			replace = range,
+		},
 		cmp = {
 			kind_text = "Codeium",
 			kind_hl_group = "CmpItemKindCodeium",


### PR DESCRIPTION
Currently when accepting a completion the suffix after the cursor is not replaced, as shown in the recording the closing `}` remains which is part of the completion:

https://github.com/jcdickinson/codeium.nvim/assets/4812676/ce171113-da2e-4e3e-b22b-d47ede676824

The Codeium API response contains information about where the completion ends that can be used to pass the full range to cmp, which results in the following:

https://github.com/jcdickinson/codeium.nvim/assets/4812676/d1a8c4ec-bed1-416f-837c-f2f00700d978

Thanks for the great plugin 🙏 