### PR TITLE
fix: correctly handle replacement for edge cases

### DIFF
--- a/lua/codeium/source.lua
+++ b/lua/codeium/source.lua
@@ -21,14 +21,29 @@ local function codeium_to_cmp(comp, offset, right)
 		label = string.sub(label, 1, -#right - 1)
 	end
 
+  -- We get the completion part that has the largest offset
+	local max_offset = offset
+	for _, v in pairs(comp.completionParts) do
+		local part_offset = tonumber(v.offset)
+		if part_offset > max_offset then
+			max_offset = part_offset
+		end
+	end
+
+  -- We get where the suffix difference between the completion and the range of code
+	local suffix_diff = comp.range.endOffset - max_offset
+
 	local range = {
 		start = {
-			line = comp.range.startPosition.row + 1,
+      -- Codeium returns an empy row for the first line
+			line = (comp.range.startPosition.row or 0) + 1,
 			character = offset - 1,
 		},
 		["end"] = {
-			line = comp.range.endPosition.row + 1,
-			character = comp.range.endPosition.col,
+      -- Codeium returns an empy row for the first line
+			line = (comp.range.endPosition.row or 0) + 1,
+      -- We only want to replace up to where the completion ends
+			character = comp.range.endPosition.col - suffix_diff,
 		},
 	}
 


### PR DESCRIPTION
I found some edge cases with my previous PR that are fixed with this one:

- Codeium does not return a row number for the first row, so we default the row to 0
- The row end col always means the end of the line, but not all completions should replace the whole line, the maximum offset from the completion parts tells us where we should actually stop, so we compare that with the offset of the end and get the right end col.

I also added some comments to make clearer what achieves what