### PR TITLE
inputsecret -> secret = true

### DIFF
--- a/lua/codeium/views/auth-menu.lua
+++ b/lua/codeium/views/auth-menu.lua
@@ -2,8 +2,9 @@ local io = require("codeium.io")
 local notify = require("codeium.notify")
 
 local function get_key(callback)
-	vim.ui.inputsecret({
+	vim.ui.input({
 		prompt = "Token ",
+		secret = true,
 		on_submit = callback,
 	}, function(result)
 		if result then


### PR DESCRIPTION
vim.ui.inputsecret does not exist. passing secret = true to vim.ui.input allows :Codeium Auth to proceed