### PR TITLE
Macos codeium support

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -41,7 +41,7 @@
             phases = ["installPhase" "fixupPhase"];
             nativeBuildInputs = [
               stdenv.cc.cc
-            ] ++ (if !stdenv.isDarwin then [ authoPatchelfHook ] else []);
+            ] ++ (if !stdenv.isDarwin then [ autoPatchelfHook ] else []);
 
             installPhase = ''
               mkdir -p $out/bin

--- a/flake.nix
+++ b/flake.nix
@@ -40,9 +40,8 @@
 
             phases = ["installPhase" "fixupPhase"];
             nativeBuildInputs = [
-              autoPatchelfHook
               stdenv.cc.cc
-            ];
+            ] ++ (if !stdenv.isDarwin then [ authoPatchelfHook ] else []);
 
             installPhase = ''
               mkdir -p $out/bin


### PR DESCRIPTION
No special dynamic linker rewriting magic is needed on macos. Change the flake to reflect this by removing autopatchelf