### PR TITLE
Make utf8len work with utf8 strings

### DIFF
--- a/lua/codeium/source.lua
+++ b/lua/codeium/source.lua
@@ -5,10 +5,8 @@ local function utf8len(str)
 	if str == "" or not str then
 		return 0
 	end
-	-- TODO: Figure out how to convert the document encoding to UTF8 length
-	-- Bonus points for doing it with raw codepoints instead of converting the
-	-- string wholesale
-	return string.len(str)
+
+	return #vim.str_utf_pos(str)
 end
 
 local function codeium_to_cmp(comp, offset, right)


### PR DESCRIPTION
Neovim has a function called `vim.str_utf_pos` which returns the first-byte index of each character in a string.
The function has been in the editor since 2021 ([#d752cbc](https://github.com/neovim/neovim/commit/d752cbc4d2ef67686acb4bbe06e8cdfa79aa23f8)) so there's no problem of people needing to have the newest version of neovim.