### PR TITLE
match nvim-cmp is_invalid check logic

### DIFF
--- a/lua/codeium/source.lua
+++ b/lua/codeium/source.lua
@@ -36,12 +36,12 @@ local function codeium_to_cmp(comp, offset, right)
 	local range = {
 		start = {
 			-- Codeium returns an empy row for the first line
-			line = (comp.range.startPosition.row or 0) + 1,
-			character = offset - 1,
+			line = (tonumber(comp.range.startPosition.row) or 0),
+			character = offset,
 		},
 		["end"] = {
 			-- Codeium returns an empy row for the first line
-			line = (comp.range.endPosition.row or 0) + 1,
+			line = (tonumber(comp.range.endPosition.row) or 0),
 			-- We only want to replace up to where the completion ends
 			character = comp.range.endPosition.col - suffix_diff,
 		},


### PR DESCRIPTION
I'm not familiar with the internal implementation of nvim-cmp, but by comparing the is_invalid implementation of nvim-cmp, I found that making this change can fix the issue where the newer version of nvim-cmp fails to display codeium suggestions.